### PR TITLE
jenkins pylint and run_with_coverage tasks are deprecated

### DIFF
--- a/blackrock/settings_shared.py
+++ b/blackrock/settings_shared.py
@@ -42,8 +42,6 @@ if 'test' in sys.argv or 'jenkins' in sys.argv or 'validate' in sys.argv:
 
 
 JENKINS_TASKS = (
-    'django_jenkins.tasks.run_pylint',
-    'django_jenkins.tasks.with_coverage',
     'django_jenkins.tasks.run_pep8',
     'django_jenkins.tasks.run_pyflakes',
 )


### PR DESCRIPTION
(and the pylint one breaks on some machines)