### PR TITLE
fix 500 error on search. PMT #101872

### DIFF
--- a/blackrock/portal/search.py
+++ b/blackrock/portal/search.py
@@ -102,10 +102,13 @@ class PortalSearchForm(SearchForm):
                                 x = Facet.objects.get(name=key)
                                 display_name = x.display_name
                             except:
-                                model = get_model("portal", key)
-                                if model:
-                                    display_name = capfirst(
-                                        model._meta.verbose_name)
+                                try:
+                                    model = get_model("portal", key)
+                                    if model:
+                                        display_name = capfirst(
+                                            model._meta.verbose_name)
+                                except LookupError:
+                                    pass
 
                             choice = (key, "%s (%s)" % (display_name, value))
                             self.fields[facet].choices.append(choice)


### PR DESCRIPTION
according to
https://sentry.ccnmtl.columbia.edu/sentry-internal/blackrock/group/772/

requests for paths like `/portal/search/?page=3` are generating 500
errors. It appears that for whatever reason, it's trying to find
`traplocation` model within `portal` instead of `mammals`. I don't know
why. Someone more familiar with blackrock's search functionality should
probably look into that.

This should at least make it just not return results instead of
generating errors.