### PR TITLE
Remove sensor param from google maps

### DIFF
--- a/blackrock/templates/mammals/base_mammals.html
+++ b/blackrock/templates/mammals/base_mammals.html
@@ -17,7 +17,7 @@
 <script  type="text/javascript" src="/site_media/js/jquery-ui-1.8.11.custom/js/jquery-ui-1.8.11.custom.min.js"></script>
 <script type="text/javascript" src="/site_media/js/libraries/jquery.sharing/jquery.sharing.js"></script>
 <script type="text/javascript" src="/site_media/js/libraries//sharing.js"></script>
-<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}&sensor=false"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}"></script>
 <script type="text/javascript" src="/site_media/js/mammals/maps.js"></script>
 {% endblock %}
 

--- a/blackrock/templates/portal/base_portal.html
+++ b/blackrock/templates/portal/base_portal.html
@@ -35,7 +35,7 @@
     <script type="text/javascript" src="/site_media/js/portal/jcarousel/lib/jquery.jcarousel.js"></script>
     <script type="text/javascript" src="/site_media/js/portal/maps.js"></script>
     <script type="text/javascript" src="/site_media/js/portal/portal.js"></script>
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}&sensor=false"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}"></script>
  
     {% endblock %}
     


### PR DESCRIPTION
Based on this warning in the JS console:

    Google Maps API warning: SensorNotRequired:
    https://developers.google.com/maps/documentation/javascript/error-messages