### PR TITLE
pinning hidden dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,18 @@ statsd==3.2.1
 six==1.10.0
 fake-factory==0.5.3
 contextlib2==0.5.1
+argparse==1.4.0
+cffi==1.2.1
+colorama==0.3.6
+cryptography==0.9.3
+enum34==1.1.1
+idna==2.0
+ipaddress==1.0.12
+lazy-object-proxy==1.2.1
+nose==1.3.7
+pycparser==2.14
+wrapt==1.10.6
+wsgiref==0.1.2
 
 django-smartif==0.1
 djangowind==0.14.3


### PR DESCRIPTION
Include the dependencies of dependencies in requirements.txt. These are
getting installed already anyway; just making the versions explicit in
requirements.txt instead of letting pip search for whatever versions of
them it finds.

Identified by doing a `pip freeze` and comparing it to the existing
requirements.txt