### PR TITLE
:arrow_up: cryptography 1.3.1, cffi 1.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ contextlib2==0.5.1
 argparse==1.4.0
 cffi==1.2.1
 colorama==0.3.6
-cryptography==0.9.3
+cryptography==1.3.1
 enum34==1.1.1
 idna==2.0
 ipaddress==1.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ six==1.10.0
 fake-factory==0.5.3
 contextlib2==0.5.1
 argparse==1.4.0
-cffi==1.2.1
+cffi==1.5.2
 colorama==0.3.6
 cryptography==1.3.1
 enum34==1.1.1


### PR DESCRIPTION
This addresses an error that occurs on OS X 10.11: https://github.com/pyca/cryptography/issues/2350