### PR TITLE
:arrow_up: Django 1.9

### DIFF
--- a/blackrock/blackrock_main/solr.py
+++ b/blackrock/blackrock_main/solr.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.tzinfo import FixedOffset
+from django.utils.timezone import FixedOffset
 from pysolr import Solr
 import urllib
 

--- a/blackrock/mammals/tests/test_views.py
+++ b/blackrock/mammals/tests/test_views.py
@@ -38,14 +38,14 @@ class BasicViewTest(TestCase):
     def test_process_login_get_fail(self):
         response = self.c.get('/mammals/process_login/')
         self.assertEqual(response.status_code, 302)
-        redirect = "mammals/login/"
+        redirect = "/mammals/login/"
         self.assertRedirects(response, redirect)
 
     # (r'^process_login/$',     'blackrock.mammals.views.process_login'),
     def test_process_login_post_fail(self):
         response = self.c.post('/mammals/process_login/')
         self.assertEqual(response.status_code, 302)
-        redirect = "mammals/login/"
+        redirect = "/mammals/login/"
         self.assertRedirects(response, redirect)
 
     def test_process_login_auth_fail(self):

--- a/blackrock/portal/models.py
+++ b/blackrock/portal/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from django import forms
 from django.conf import settings
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.gis.db import models
 from django.db.models.signals import pre_save
 from pagetree.models import PageBlock
@@ -531,8 +531,7 @@ class ForestStory(models.Model):
 
 
 class AssetList(models.Model):
-    pageblocks = generic.GenericRelation(
-        PageBlock)
+    pageblocks = GenericRelation(PageBlock)
     search_criteria = models.TextField()
     template_file = "portal/assetlist.html"
     display_name = "Asset List"
@@ -605,8 +604,7 @@ class AssetList(models.Model):
 
 
 class FeaturedAsset(models.Model):
-    pageblocks = generic.GenericRelation(
-        PageBlock)
+    pageblocks = GenericRelation(PageBlock)
     audience = models.ForeignKey(Audience)
     detailed_display = models.BooleanField(default=False)
 
@@ -724,8 +722,7 @@ class PhotoGalleryItem(models.Model):
 
 
 class PhotoGallery(models.Model):
-    pageblocks = generic.GenericRelation(
-        PageBlock)
+    pageblocks = GenericRelation(PageBlock)
     template_file = "portal/photogallery.html"
     display_name = "Photo Gallery"
     item = models.ManyToManyField(PhotoGalleryItem, blank=True)
@@ -770,8 +767,7 @@ class PhotoGalleryForm(forms.ModelForm):
 
 
 class Webcam(models.Model):
-    pageblocks = generic.GenericRelation(
-        PageBlock)
+    pageblocks = GenericRelation(PageBlock)
     template_file = "portal/webcam.html"
     display_name = "Webcam"
 
@@ -809,8 +805,7 @@ class WebcamForm(forms.ModelForm):
 
 
 class InteractiveMap(models.Model):
-    pageblocks = generic.GenericRelation(
-        PageBlock)
+    pageblocks = GenericRelation(PageBlock)
     template_file = "portal/interactive_map.html"
     display_name = "Interactive Map"
 

--- a/blackrock/portal/search.py
+++ b/blackrock/portal/search.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.db.models import get_model
+from django.apps import apps
 from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 from haystack.forms import SearchForm
@@ -130,7 +130,7 @@ def get_facet_display_name(key):
         display_name = x.display_name
     except:
         try:
-            model = get_model("portal", key)
+            model = apps.get_model("portal", key)
             if model:
                 display_name = capfirst(
                     model._meta.verbose_name)

--- a/blackrock/portal/views.py
+++ b/blackrock/portal/views.py
@@ -7,16 +7,17 @@ from pysolr import Solr, SolrError
 from time import strptime
 from datetime import date
 from decimal import Decimal
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib.gis.measure import D  # D is a shortcut for Distance
 from django.core import management
 from django.core.cache import cache
-from django.db.models import get_model, DateField
+from django.db.models import DateField
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext, Context
-from django.utils.tzinfo import FixedOffset
+from django.utils.timezone import FixedOffset
 from django.contrib.gis.geos import fromstr
 from pagetree.models import Hierarchy
 from blackrock.portal.models import Location, DataSet, Audience
@@ -62,7 +63,7 @@ def page(request, path):
 
     if asset_type and asset_id:
         try:
-            model = get_model("portal", asset_type)
+            model = apps.get_model("portal", asset_type)
             context['selected'] = model.objects.get(id=asset_id)
         except:
             msg = "We were unable to locate a <b>%s</b> at this address."
@@ -195,7 +196,7 @@ def process_metadata(result):
 
     for field in dataset._meta.many_to_many:
         if field.name in values.keys():
-            related_model = get_model("portal", field.name)
+            related_model = apps.get_model("portal", field.name)
             for v in values[field.name]:
                 if field.name == 'url':
                     v = settings.CDRS_SOLR_FILEURL + v

--- a/blackrock/respiration/views.py
+++ b/blackrock/respiration/views.py
@@ -10,7 +10,7 @@ from django.http import HttpResponse, HttpResponseRedirect, \
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from json import dumps
-from django.utils.tzinfo import FixedOffset
+from django.utils.timezone import FixedOffset
 from pysolr import Solr
 from blackrock.respiration.models import Temperature, StationMapping
 import csv

--- a/blackrock/settings_shared.py
+++ b/blackrock/settings_shared.py
@@ -65,7 +65,6 @@ INSTALLED_APPS += [  # noqa
     'tinymce',
     'pagetree',
     'pageblocks',
-    'template_utils',
     'blackrock.waterquality',
     'blackrock.mammals',
     'bootstrapform',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # local pysqlite that is configured to load C extensions
 # see: https://docs.djangoproject.com/en/dev/ref/contrib/gis/install/spatialite/#pysqlite2
 requirements/src/pysqlite-2.6.3.tar.gz
-Django==1.8.13
+Django==1.9.7
 pytz==2016.4
 resolver==0.2.1
 selector==0.10.1
@@ -58,7 +58,6 @@ sqlparse==0.1.19
 djangowind==0.14.3
 sorl==3.1
 tagging==0.3-pre
-template_utils==0.4p2
 django-indexer==0.3.0
 django-templatetag-sugar==1.0
 django-statsd-mozilla==0.3.16
@@ -66,7 +65,7 @@ django-paging==0.2.5
 django-appconf==1.0.2
 django-compressor==2.0
 raven==5.19.0
-django-googlecharts==1.0-alpha-1
+django-googlecharts==1.1.2-ccnmtl
 django-jenkins==0.18.1
 django-stagingcontext==0.1.0
 django-smoketest==1.0.0
@@ -76,7 +75,7 @@ django-bootstrap-form==3.2.1
 django-markwhat==1.5
 django-pagetree==1.1.15
 django-pageblocks==1.0.4
-django-databrowse==2014.9.26
+django-databrowse==1.2
 factory_boy==2.7.0
 django-debug-toolbar==1.4
 gunicorn==19.6.0


### PR DESCRIPTION
django-haystack 2.4.1 appears to work with Django 1.9, so that's no
longer the blocker.

Some things I did run into:

* had to fork the now unmaintained django-googlecharts
* django-databrowse 2014.9.26 breaks under 1.9, but the older 1.2
  version seems to work fine with 1.9, so I dropped it back to that
  until a newer version comes out
* template_utls doesn't work with 1.9. AFAICT, it was being imported and
  added to INSTALLED_APPS, but never actually used, so I just removed it.