### PR TITLE
Limit date range on CSV export - PMT #107061

### DIFF
--- a/media/js/src/treegrowth/graph.js
+++ b/media/js/src/treegrowth/graph.js
@@ -10,6 +10,11 @@
             rangeSelector: {
                 selected: 1
             },
+            navigator: {
+                series: {
+                    includeInCSVExport: false
+                }
+            },
             data: {
                 rows: data
             },


### PR DESCRIPTION
This change causes the exported CSV to only contain rows present in the
selected date range.