### PR TITLE
Django 1.10 urls

### DIFF
--- a/blackrock/blackrock_main/urls.py
+++ b/blackrock/blackrock_main/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
-
+from .views import loadsolr_poll, previewsolr
 
 urlpatterns = [
-    url(r'^loadsolrpoll$', 'blackrock.blackrock_main.views.loadsolr_poll'),
-    url(r'^previewsolr$', 'blackrock.blackrock_main.views.previewsolr')
+    url(r'^loadsolrpoll$', loadsolr_poll),
+    url(r'^previewsolr$', previewsolr),
 ]

--- a/blackrock/blackrock_main/urls.py
+++ b/blackrock/blackrock_main/urls.py
@@ -1,8 +1,7 @@
-from django.conf.urls import patterns
+from django.conf.urls import url
 
 
-urlpatterns = patterns(
-    '',
-    (r'^loadsolrpoll$', 'blackrock.blackrock_main.views.loadsolr_poll'),
-    (r'^previewsolr$', 'blackrock.blackrock_main.views.previewsolr')
-)
+urlpatterns = [
+    url(r'^loadsolrpoll$', 'blackrock.blackrock_main.views.loadsolr_poll'),
+    url(r'^previewsolr$', 'blackrock.blackrock_main.views.previewsolr')
+]

--- a/blackrock/mammals/urls.py
+++ b/blackrock/mammals/urls.py
@@ -1,90 +1,79 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 import os.path
 from blackrock.mammals.search import MammalSearchView, MammalSearchForm
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
-urlpatterns = patterns(
-    '',
-
-    (r'^media/(?P<path>.*)$', 'django.views.static.serve',
-     {'document_root': media_root}),
+urlpatterns = [
+    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': media_root}),
 
     # Research version:
-    (r'^$', 'blackrock.mammals.views.index'),
-    (r'^grid/$', 'blackrock.mammals.views.grid'),
-    (r'^grid_square/$',
-     'blackrock.mammals.views.grid_block'),
+    url(r'^$', 'blackrock.mammals.views.index'),
+    url(r'^grid/$', 'blackrock.mammals.views.grid'),
+    url(r'^grid_square/$',
+        'blackrock.mammals.views.grid_block'),
 
     # printer and csv versions of the grid square:
-    (r'^grid_square_csv/$',
-     'blackrock.mammals.views.grid_square_csv'),
-    (r'^grid_square_print/$',
-     'blackrock.mammals.views.grid_square_print'),
+    url(r'^grid_square_csv/$',
+        'blackrock.mammals.views.grid_square_csv'),
+    url(r'^grid_square_print/$',
+        'blackrock.mammals.views.grid_square_print'),
 
     # Sandbox version:
-    (r'^sandbox/$',
-     'blackrock.mammals.views.sandbox_grid'),
-    (r'^sandbox/grid/$',
-     'blackrock.mammals.views.sandbox_grid'),
-    (r'^sandbox/grid_square/$',
-     'blackrock.mammals.views.sandbox_grid_block'),
+    url(r'^sandbox/$',
+        'blackrock.mammals.views.sandbox_grid'),
+    url(r'^sandbox/grid/$',
+        'blackrock.mammals.views.sandbox_grid'),
+    url(r'^sandbox/grid_square/$',
+        'blackrock.mammals.views.sandbox_grid_block'),
 
+    url(r'^help/$',
+        'blackrock.mammals.views.help'),
+    url(r'^teaching/$', 'blackrock.mammals.views.teaching_resources'),
 
-    (r'^help/$',
-     'blackrock.mammals.views.help'),
-    (r'^teaching/$', 'blackrock.mammals.views.teaching_resources'),
+    url(r'^login/$',
+        'blackrock.mammals.views.mammals_login'),
 
+    url(r'^process_login/$',
+        'blackrock.mammals.views.process_login'),
+    url(r'^logout/$', 'django.contrib.auth.views.logout',
+        {'next_page': '/mammals/'}),
 
-    (r'^login/$',
-     'blackrock.mammals.views.mammals_login'),
+    url(r'^all_expeditions/$',
+        'blackrock.mammals.views.all_expeditions'),
 
-    (r'^process_login/$',
-     'blackrock.mammals.views.process_login'),
-    (r'^logout/$', 'django.contrib.auth.views.logout',
-     {'next_page': '/mammals/'}),
+    url(r'^new_expedition_ajax/$',
+        'blackrock.mammals.views.new_expedition_ajax'),
 
-    (r'^all_expeditions/$',
-     'blackrock.mammals.views.all_expeditions'),
+    url(r'^expedition/(?P<expedition_id>\d+)/$',
+        'blackrock.mammals.views.expedition'),
+    url(r'^edit_expedition/(?P<expedition_id>\d+)/$',
+        'blackrock.mammals.views.edit_expedition'),
+    url(r'^edit_expedition_ajax/$',
+        'blackrock.mammals.views.edit_expedition_ajax'),
 
+    url(r'^sightings/$', 'blackrock.mammals.views.sightings'),
+    url(r'^create_sighting/$',
+        'blackrock.mammals.views.create_sighting'),
+    url(r'^sighting/(?P<sighting_id>\d+)/$',
+        'blackrock.mammals.views.sighting'),
+    url(r'^edit_sighting/$',
+        'blackrock.mammals.views.edit_sighting'),
 
-    (r'^new_expedition_ajax/$',
-     'blackrock.mammals.views.new_expedition_ajax'),
+    url(r'^expedition/(?P<expedition_id>\d+)/animals/$',
+        'blackrock.mammals.views.expedition_animals'),
 
+    url(r'^save_expedition_animals/$',
+        'blackrock.mammals.views.save_expedition_animals'),
 
-    (r'^expedition/(?P<expedition_id>\d+)/$',
-     'blackrock.mammals.views.expedition'),
-    (r'^edit_expedition/(?P<expedition_id>\d+)/$',
-     'blackrock.mammals.views.edit_expedition'),
-    (r'^edit_expedition_ajax/$',
-     'blackrock.mammals.views.edit_expedition_ajax'),
+    url(r'^team_form/(?P<expedition_id>\d+)/(?P<team_letter>\w+)/$',
+        'blackrock.mammals.views.team_form'),
 
-
-    (r'^sightings/$', 'blackrock.mammals.views.sightings'),
-    (r'^create_sighting/$',
-     'blackrock.mammals.views.create_sighting'),
-    (r'^sighting/(?P<sighting_id>\d+)/$',
-     'blackrock.mammals.views.sighting'),
-    (r'^edit_sighting/$',
-     'blackrock.mammals.views.edit_sighting'),
-
-
-    (r'^expedition/(?P<expedition_id>\d+)/animals/$',
-     'blackrock.mammals.views.expedition_animals'),
-
-
-    (r'^save_expedition_animals/$',
-     'blackrock.mammals.views.save_expedition_animals'),
-
-
-    (r'^team_form/(?P<expedition_id>\d+)/(?P<team_letter>\w+)/$',
-     'blackrock.mammals.views.team_form'),
-
-
-    (r'^save_team_form/$',
-     'blackrock.mammals.views.save_team_form'),
-    (r'^save_team_form_ajax/$',
-     'blackrock.mammals.views.save_team_form_ajax'),
+    url(r'^save_team_form/$',
+        'blackrock.mammals.views.save_team_form'),
+    url(r'^save_team_form_ajax/$',
+        'blackrock.mammals.views.save_team_form_ajax'),
 
     url(r'^search/',
         MammalSearchView(template="mammals/search.html",
@@ -92,4 +81,4 @@ urlpatterns = patterns(
 
     url(r'^ajax_search/$',
         'blackrock.mammals.search.ajax_search'),
-)
+]

--- a/blackrock/mammals/urls.py
+++ b/blackrock/mammals/urls.py
@@ -1,84 +1,68 @@
 from django.conf.urls import url
 import os.path
-from blackrock.mammals.search import MammalSearchView, MammalSearchForm
+import django.views.static
+from django.contrib.auth.views import logout
+
+from .search import MammalSearchView, MammalSearchForm, ajax_search
+from .views import (
+    index, grid, grid_block, grid_square_csv, grid_square_print,
+    process_login, save_team_form, all_expeditions,
+    team_form, mammals_login, sandbox_grid, teaching_resources,
+    sightings, edit_sighting, create_sighting, new_expedition_ajax,
+    sandbox_grid_block, sighting, expedition, edit_expedition,
+    save_team_form_ajax, edit_expedition_ajax, save_expedition_animals,
+    expedition_animals, help,
+)
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
 urlpatterns = [
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^media/(?P<path>.*)$', django.views.static.serve,
         {'document_root': media_root}),
 
     # Research version:
-    url(r'^$', 'blackrock.mammals.views.index'),
-    url(r'^grid/$', 'blackrock.mammals.views.grid'),
-    url(r'^grid_square/$',
-        'blackrock.mammals.views.grid_block'),
+    url(r'^$', index),
+    url(r'^grid/$', grid),
+    url(r'^grid_square/$', grid_block),
 
     # printer and csv versions of the grid square:
-    url(r'^grid_square_csv/$',
-        'blackrock.mammals.views.grid_square_csv'),
-    url(r'^grid_square_print/$',
-        'blackrock.mammals.views.grid_square_print'),
+    url(r'^grid_square_csv/$', grid_square_csv),
+    url(r'^grid_square_print/$', grid_square_print),
 
     # Sandbox version:
-    url(r'^sandbox/$',
-        'blackrock.mammals.views.sandbox_grid'),
-    url(r'^sandbox/grid/$',
-        'blackrock.mammals.views.sandbox_grid'),
-    url(r'^sandbox/grid_square/$',
-        'blackrock.mammals.views.sandbox_grid_block'),
+    url(r'^sandbox/$', sandbox_grid),
+    url(r'^sandbox/grid/$', sandbox_grid),
+    url(r'^sandbox/grid_square/$', sandbox_grid_block),
 
-    url(r'^help/$',
-        'blackrock.mammals.views.help'),
-    url(r'^teaching/$', 'blackrock.mammals.views.teaching_resources'),
+    url(r'^help/$', help),
+    url(r'^teaching/$', teaching_resources),
 
-    url(r'^login/$',
-        'blackrock.mammals.views.mammals_login'),
+    url(r'^login/$', mammals_login),
 
-    url(r'^process_login/$',
-        'blackrock.mammals.views.process_login'),
-    url(r'^logout/$', 'django.contrib.auth.views.logout',
-        {'next_page': '/mammals/'}),
+    url(r'^process_login/$', process_login),
+    url(r'^logout/$', logout, {'next_page': '/mammals/'}),
 
-    url(r'^all_expeditions/$',
-        'blackrock.mammals.views.all_expeditions'),
+    url(r'^all_expeditions/$', all_expeditions),
+    url(r'^new_expedition_ajax/$', new_expedition_ajax),
+    url(r'^expedition/(?P<expedition_id>\d+)/$', expedition),
+    url(r'^edit_expedition/(?P<expedition_id>\d+)/$', edit_expedition),
+    url(r'^edit_expedition_ajax/$', edit_expedition_ajax),
 
-    url(r'^new_expedition_ajax/$',
-        'blackrock.mammals.views.new_expedition_ajax'),
+    url(r'^sightings/$', sightings),
+    url(r'^create_sighting/$', create_sighting),
+    url(r'^sighting/(?P<sighting_id>\d+)/$', sighting),
+    url(r'^edit_sighting/$', edit_sighting),
 
-    url(r'^expedition/(?P<expedition_id>\d+)/$',
-        'blackrock.mammals.views.expedition'),
-    url(r'^edit_expedition/(?P<expedition_id>\d+)/$',
-        'blackrock.mammals.views.edit_expedition'),
-    url(r'^edit_expedition_ajax/$',
-        'blackrock.mammals.views.edit_expedition_ajax'),
-
-    url(r'^sightings/$', 'blackrock.mammals.views.sightings'),
-    url(r'^create_sighting/$',
-        'blackrock.mammals.views.create_sighting'),
-    url(r'^sighting/(?P<sighting_id>\d+)/$',
-        'blackrock.mammals.views.sighting'),
-    url(r'^edit_sighting/$',
-        'blackrock.mammals.views.edit_sighting'),
-
-    url(r'^expedition/(?P<expedition_id>\d+)/animals/$',
-        'blackrock.mammals.views.expedition_animals'),
-
-    url(r'^save_expedition_animals/$',
-        'blackrock.mammals.views.save_expedition_animals'),
-
+    url(r'^expedition/(?P<expedition_id>\d+)/animals/$', expedition_animals),
+    url(r'^save_expedition_animals/$', save_expedition_animals),
     url(r'^team_form/(?P<expedition_id>\d+)/(?P<team_letter>\w+)/$',
-        'blackrock.mammals.views.team_form'),
-
-    url(r'^save_team_form/$',
-        'blackrock.mammals.views.save_team_form'),
-    url(r'^save_team_form_ajax/$',
-        'blackrock.mammals.views.save_team_form_ajax'),
+        team_form),
+    url(r'^save_team_form/$', save_team_form),
+    url(r'^save_team_form_ajax/$', save_team_form_ajax),
 
     url(r'^search/',
         MammalSearchView(template="mammals/search.html",
                          form_class=MammalSearchForm), name='search'),
 
-    url(r'^ajax_search/$',
-        'blackrock.mammals.search.ajax_search'),
+    url(r'^ajax_search/$', ajax_search),
 ]

--- a/blackrock/optimization/urls.py
+++ b/blackrock/optimization/urls.py
@@ -1,21 +1,20 @@
-from django.conf.urls import patterns
+from django.conf.urls import url
 import os.path
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
-urlpatterns = patterns(
-    '',
-    (r'^$', 'blackrock.optimization.views.index'),
-    (r'^run$', 'blackrock.optimization.views.run'),
-    (r'^calculate$', 'blackrock.optimization.views.calculate'),
-    (r'^trees.png$', 'blackrock.optimization.views.tree_png'),
+urlpatterns = [
+    url(r'^$', 'blackrock.optimization.views.index'),
+    url(r'^run$', 'blackrock.optimization.views.run'),
+    url(r'^calculate$', 'blackrock.optimization.views.calculate'),
+    url(r'^trees.png$', 'blackrock.optimization.views.tree_png'),
 
-    (r'^csv$', 'blackrock.optimization.views.export_csv'),
-    (r'^json2csv$', 'blackrock.optimization.views.json2csv'),
-    (r'^trees_csv$', 'blackrock.optimization.views.trees_csv'),
+    url(r'^csv$', 'blackrock.optimization.views.export_csv'),
+    url(r'^json2csv$', 'blackrock.optimization.views.json2csv'),
+    url(r'^trees_csv$', 'blackrock.optimization.views.trees_csv'),
 
-    (r'^test$', 'blackrock.optimization.views.test'),
-    (r'^loadcsv$', 'blackrock.optimization.views.loadcsv'),
-    (r'^media/(?P<path>.*)$', 'django.views.static.serve',
-     {'document_root': media_root}),
-)
+    url(r'^test$', 'blackrock.optimization.views.test'),
+    url(r'^loadcsv$', 'blackrock.optimization.views.loadcsv'),
+    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': media_root}),
+]

--- a/blackrock/optimization/urls.py
+++ b/blackrock/optimization/urls.py
@@ -1,20 +1,25 @@
 from django.conf.urls import url
 import os.path
+import django.views.static
+from .views import (
+    index, run, calculate, tree_png, export_csv, json2csv, trees_csv,
+    test, loadcsv,
+)
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
 urlpatterns = [
-    url(r'^$', 'blackrock.optimization.views.index'),
-    url(r'^run$', 'blackrock.optimization.views.run'),
-    url(r'^calculate$', 'blackrock.optimization.views.calculate'),
-    url(r'^trees.png$', 'blackrock.optimization.views.tree_png'),
+    url(r'^$', index),
+    url(r'^run$', run),
+    url(r'^calculate$', calculate),
+    url(r'^trees.png$', tree_png),
 
-    url(r'^csv$', 'blackrock.optimization.views.export_csv'),
-    url(r'^json2csv$', 'blackrock.optimization.views.json2csv'),
-    url(r'^trees_csv$', 'blackrock.optimization.views.trees_csv'),
+    url(r'^csv$', export_csv),
+    url(r'^json2csv$', json2csv),
+    url(r'^trees_csv$', trees_csv),
 
-    url(r'^test$', 'blackrock.optimization.views.test'),
-    url(r'^loadcsv$', 'blackrock.optimization.views.loadcsv'),
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^test$', test),
+    url(r'^loadcsv$', loadcsv),
+    url(r'^media/(?P<path>.*)$', django.views.static.serve,
         {'document_root': media_root}),
 ]

--- a/blackrock/paleoecology/urls.py
+++ b/blackrock/paleoecology/urls.py
@@ -1,25 +1,24 @@
 import os.path
 
-from django.conf.urls import patterns
+from django.conf.urls import url
 from django.views.generic.base import TemplateView
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 data_root = os.path.join(os.path.dirname(__file__), "data")
 
-urlpatterns = patterns(
-    '',
-    (r'^$', 'blackrock.paleoecology.views.index'),
-    (r'^identification$',
-     TemplateView.as_view(template_name='paleoecology/identification.html')),
-    (r'^explore$', 'blackrock.paleoecology.views.explore'),
-    (r'^resources$',
-     TemplateView.as_view(template_name='paleoecology/resources.html')),
-    (r'^getpercents$', 'blackrock.paleoecology.views.getpercents'),
-    (r'^media/(?P<path>.*)$', 'django.views.static.serve',
+urlpatterns = [
+    url(r'^$', 'blackrock.paleoecology.views.index'),
+    url(r'^identification$', TemplateView.as_view(
+        template_name='paleoecology/identification.html')),
+    url(r'^explore$', 'blackrock.paleoecology.views.explore'),
+    url(r'^resources$',
+        TemplateView.as_view(template_name='paleoecology/resources.html')),
+    url(r'^getpercents$', 'blackrock.paleoecology.views.getpercents'),
+    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': media_root}),
-    (r'^data/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^data/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': data_root}),
-    (r'^loadcounts$', 'blackrock.paleoecology.views.loadcounts'),
-    (r'^loadpercents$', 'blackrock.paleoecology.views.loadpercents'),
-    (r'^loadsolr$', 'blackrock.paleoecology.views.loadsolr')
-)
+    url(r'^loadcounts$', 'blackrock.paleoecology.views.loadcounts'),
+    url(r'^loadpercents$', 'blackrock.paleoecology.views.loadpercents'),
+    url(r'^loadsolr$', 'blackrock.paleoecology.views.loadsolr')
+]

--- a/blackrock/paleoecology/urls.py
+++ b/blackrock/paleoecology/urls.py
@@ -1,24 +1,29 @@
 import os.path
+import django.views.static
 
 from django.conf.urls import url
 from django.views.generic.base import TemplateView
+
+from .views import (
+    index, explore, getpercents, loadcounts, loadpercents, loadsolr
+)
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 data_root = os.path.join(os.path.dirname(__file__), "data")
 
 urlpatterns = [
-    url(r'^$', 'blackrock.paleoecology.views.index'),
+    url(r'^$', index),
     url(r'^identification$', TemplateView.as_view(
         template_name='paleoecology/identification.html')),
-    url(r'^explore$', 'blackrock.paleoecology.views.explore'),
-    url(r'^resources$',
-        TemplateView.as_view(template_name='paleoecology/resources.html')),
-    url(r'^getpercents$', 'blackrock.paleoecology.views.getpercents'),
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^explore$', explore),
+    url(r'^resources$', TemplateView.as_view(
+        template_name='paleoecology/resources.html')),
+    url(r'^getpercents$', getpercents),
+    url(r'^media/(?P<path>.*)$', django.views.static.serve,
         {'document_root': media_root}),
-    url(r'^data/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^data/(?P<path>.*)$', django.views.static.serve,
         {'document_root': data_root}),
-    url(r'^loadcounts$', 'blackrock.paleoecology.views.loadcounts'),
-    url(r'^loadpercents$', 'blackrock.paleoecology.views.loadpercents'),
-    url(r'^loadsolr$', 'blackrock.paleoecology.views.loadsolr')
+    url(r'^loadcounts$', loadcounts),
+    url(r'^loadpercents$', loadpercents),
+    url(r'^loadsolr$', loadsolr)
 ]

--- a/blackrock/portal/urls.py
+++ b/blackrock/portal/urls.py
@@ -1,6 +1,6 @@
 import os.path
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic.base import TemplateView
 import django_databrowse
 
@@ -9,12 +9,11 @@ from blackrock.portal.search import PortalSearchView, PortalSearchForm
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
-urlpatterns = patterns(
-    '',
-    (r'^media/(?P<path>.*)$', 'django.views.static.serve',
-     {'document_root': media_root}),
+urlpatterns = [
+    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': media_root}),
 
-    (r'^browse/(.*)', django_databrowse.site.root),
+    url(r'^browse/(.*)', django_databrowse.site.root),
 
     url(r'^search/',
         PortalSearchView(template="portal/search.html",
@@ -27,5 +26,5 @@ urlpatterns = patterns(
     url(r'^weather/$',
         TemplateView.as_view(template_name='portal/weather.html')),
 
-    (r'^(?P<path>.*)$', 'blackrock.portal.views.page')
-)
+    url(r'^(?P<path>.*)$', 'blackrock.portal.views.page')
+]

--- a/blackrock/portal/urls.py
+++ b/blackrock/portal/urls.py
@@ -1,4 +1,5 @@
 import os.path
+import django.views.static
 
 from django.conf.urls import url
 from django.views.generic.base import TemplateView
@@ -6,25 +7,20 @@ import django_databrowse
 
 from blackrock.portal.search import PortalSearchView, PortalSearchForm
 
+from .views import page, nearby
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
 urlpatterns = [
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^media/(?P<path>.*)$', django.views.static.serve,
         {'document_root': media_root}),
-
     url(r'^browse/(.*)', django_databrowse.site.root),
-
-    url(r'^search/',
-        PortalSearchView(template="portal/search.html",
-                         form_class=PortalSearchForm),
-        name='search'),
-
+    url(r'^search/', PortalSearchView(
+        template="portal/search.html",
+        form_class=PortalSearchForm), name='search'),
     url(r'^nearby/(?P<latitude>-?\d+\.\d+)/(?P<longitude>-?\d+\.\d+)/$',
-        'blackrock.portal.views.nearby'),
-
-    url(r'^weather/$',
-        TemplateView.as_view(template_name='portal/weather.html')),
-
-    url(r'^(?P<path>.*)$', 'blackrock.portal.views.page')
+        nearby),
+    url(r'^weather/$', TemplateView.as_view(
+        template_name='portal/weather.html')),
+    url(r'^(?P<path>.*)$', page)
 ]

--- a/blackrock/respiration/urls.py
+++ b/blackrock/respiration/urls.py
@@ -1,22 +1,21 @@
 import os.path
 
-from django.conf.urls import patterns
+from django.conf.urls import url
 from django.views.generic.base import TemplateView
 
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
-urlpatterns = patterns(
-    '',
-    (r'^$', 'blackrock.respiration.views.index'),
-    (r'^leaf$', 'blackrock.respiration.views.leaf'),
-    (r'^forest$', 'blackrock.respiration.views.forest'),
-    (r'^resources/',
-     TemplateView.as_view(template_name='respiration/resources.html')),
-    (r'^media/(?P<path>.*)$', 'django.views.static.serve', {
-     'document_root': media_root}),
-    (r'^loadcsv$', 'blackrock.respiration.views.loadcsv'),
-    (r'^getcsv$', 'blackrock.respiration.views.getcsv'),
-    (r'^getsum$', 'blackrock.respiration.views.getsum'),
-    (r'^loadsolr$', 'blackrock.respiration.views.loadsolr')
-)
+urlpatterns = [
+    url(r'^$', 'blackrock.respiration.views.index'),
+    url(r'^leaf$', 'blackrock.respiration.views.leaf'),
+    url(r'^forest$', 'blackrock.respiration.views.forest'),
+    url(r'^resources/',
+        TemplateView.as_view(template_name='respiration/resources.html')),
+    url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {
+        'document_root': media_root}),
+    url(r'^loadcsv$', 'blackrock.respiration.views.loadcsv'),
+    url(r'^getcsv$', 'blackrock.respiration.views.getcsv'),
+    url(r'^getsum$', 'blackrock.respiration.views.getsum'),
+    url(r'^loadsolr$', 'blackrock.respiration.views.loadsolr')
+]

--- a/blackrock/respiration/urls.py
+++ b/blackrock/respiration/urls.py
@@ -2,20 +2,24 @@ import os.path
 
 from django.conf.urls import url
 from django.views.generic.base import TemplateView
+from django.views.static import serve
+
+from .views import (
+    index, leaf, forest, loadcsv, getcsv, getsum, loadsolr,
+)
 
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
 urlpatterns = [
-    url(r'^$', 'blackrock.respiration.views.index'),
-    url(r'^leaf$', 'blackrock.respiration.views.leaf'),
-    url(r'^forest$', 'blackrock.respiration.views.forest'),
-    url(r'^resources/',
-        TemplateView.as_view(template_name='respiration/resources.html')),
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {
-        'document_root': media_root}),
-    url(r'^loadcsv$', 'blackrock.respiration.views.loadcsv'),
-    url(r'^getcsv$', 'blackrock.respiration.views.getcsv'),
-    url(r'^getsum$', 'blackrock.respiration.views.getsum'),
-    url(r'^loadsolr$', 'blackrock.respiration.views.loadsolr')
+    url(r'^$', index),
+    url(r'^leaf$', leaf),
+    url(r'^forest$', forest),
+    url(r'^resources/', TemplateView.as_view(
+        template_name='respiration/resources.html')),
+    url(r'^media/(?P<path>.*)$', serve, {'document_root': media_root}),
+    url(r'^loadcsv$', loadcsv),
+    url(r'^getcsv$', getcsv),
+    url(r'^getsum$', getsum),
+    url(r'^loadsolr$', loadsolr)
 ]

--- a/blackrock/sampler/urls.py
+++ b/blackrock/sampler/urls.py
@@ -1,15 +1,19 @@
-from django.conf.urls import url
 import os.path
+from django.conf.urls import url
+from django.views.static import serve
+
+from .views import (
+    index, plot, transect, worksheet, export_csv, import_csv,
+)
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
 urlpatterns = [
-    url(r'^$', 'blackrock.sampler.views.index'),
-    url(r'^plot$', 'blackrock.sampler.views.plot'),
-    url(r'^transect$', 'blackrock.sampler.views.transect'),
-    url(r'^worksheet$', 'blackrock.sampler.views.worksheet'),
-    url(r'^csv$', 'blackrock.sampler.views.export_csv'),
-    url(r'^import_csv$', 'blackrock.sampler.views.import_csv'),
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
-        {'document_root': media_root}),
+    url(r'^$', index),
+    url(r'^plot$', plot),
+    url(r'^transect$', transect),
+    url(r'^worksheet$', worksheet),
+    url(r'^csv$', export_csv),
+    url(r'^import_csv$', import_csv),
+    url(r'^media/(?P<path>.*)$', serve, {'document_root': media_root}),
 ]

--- a/blackrock/sampler/urls.py
+++ b/blackrock/sampler/urls.py
@@ -1,16 +1,15 @@
-from django.conf.urls import patterns
+from django.conf.urls import url
 import os.path
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
 
-urlpatterns = patterns(
-    '',
-    (r'^$', 'blackrock.sampler.views.index'),
-    (r'^plot$', 'blackrock.sampler.views.plot'),
-    (r'^transect$', 'blackrock.sampler.views.transect'),
-    (r'^worksheet$', 'blackrock.sampler.views.worksheet'),
-    (r'^csv$', 'blackrock.sampler.views.export_csv'),
-    (r'^import_csv$', 'blackrock.sampler.views.import_csv'),
-    (r'^media/(?P<path>.*)$', 'django.views.static.serve',
-     {'document_root': media_root}),
-)
+urlpatterns = [
+    url(r'^$', 'blackrock.sampler.views.index'),
+    url(r'^plot$', 'blackrock.sampler.views.plot'),
+    url(r'^transect$', 'blackrock.sampler.views.transect'),
+    url(r'^worksheet$', 'blackrock.sampler.views.worksheet'),
+    url(r'^csv$', 'blackrock.sampler.views.export_csv'),
+    url(r'^import_csv$', 'blackrock.sampler.views.import_csv'),
+    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': media_root}),
+]

--- a/blackrock/treegrowth/urls.py
+++ b/blackrock/treegrowth/urls.py
@@ -1,13 +1,12 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic.base import TemplateView
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$',
         TemplateView.as_view(template_name='treegrowth/index.html'),
         name='treegrowth-index'),
     url(r'^graph/$',
         TemplateView.as_view(template_name='treegrowth/graph.html'),
         name='treegrowth-graph'),
-)
+]

--- a/blackrock/urls.py
+++ b/blackrock/urls.py
@@ -4,7 +4,13 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib.auth.decorators import login_required
 from django.contrib.gis import admin
+from django.views.static import serve
 from pagetree.generic.views import EditView
+
+from blackrock.portal.views import (
+    admin_rebuild_index, admin_cdrs_import, admin_readercycle,
+)
+from blackrock.views import index
 
 
 admin.autodiscover()
@@ -15,16 +21,13 @@ urlpatterns = [
     url('^accounts/', include('djangowind.urls')),
     url(r'^smoketest/', include('smoketest.urls')),
     url(r'^pagetree/', include('pagetree.urls')),
-    url(r'^admin/portal/rebuild_index',
-        'blackrock.portal.views.admin_rebuild_index'),
-    url(r'^admin/portal/import_cdrs',
-        'blackrock.portal.views.admin_cdrs_import'),
-    url(r'^admin/portal/readercycle',
-        'blackrock.portal.views.admin_readercycle'),
+    url(r'^admin/portal/rebuild_index', admin_rebuild_index),
+    url(r'^admin/portal/import_cdrs', admin_cdrs_import),
+    url(r'^admin/portal/readercycle', admin_readercycle),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^site_media/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^site_media/(?P<path>.*)$', serve,
         {'document_root': site_media_root}),
-    url(r'^uploads/(?P<path>.*)$', 'django.views.static.serve',
+    url(r'^uploads/(?P<path>.*)$', serve,
         {'document_root': settings.MEDIA_ROOT}),
     url(r'^sampler/', include('blackrock.sampler.urls')),
     url(r'^respiration/', include('blackrock.respiration.urls')),
@@ -40,7 +43,7 @@ urlpatterns = [
         hierarchy_name="main", hierarchy_base="/"))),
     url(r'^portal/', include('blackrock.portal.urls')),
     url(r'^mammals/', include('blackrock.mammals.urls')),
-    url(r'^$', 'blackrock.views.index'),
-    url(r'^uploads/(?P<path>.*)$',
-        'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
+    url(r'^$', index),
+    url(r'^uploads/(?P<path>.*)$', serve,
+        {'document_root': settings.MEDIA_ROOT}),
 ]

--- a/blackrock/urls.py
+++ b/blackrock/urls.py
@@ -1,7 +1,7 @@
 import os.path
 
 from django.conf import settings
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 from django.contrib.auth.decorators import login_required
 from django.contrib.gis import admin
 from pagetree.generic.views import EditView
@@ -11,35 +11,36 @@ admin.autodiscover()
 
 site_media_root = os.path.join(os.path.dirname(__file__), "../media")
 
-urlpatterns = patterns(
-    '',
-    ('^accounts/', include('djangowind.urls')),
-    (r'^smoketest/', include('smoketest.urls')),
-    (r'^pagetree/', include('pagetree.urls')),
-    (r'^admin/portal/rebuild_index',
-     'blackrock.portal.views.admin_rebuild_index'),
-    (r'^admin/portal/import_cdrs', 'blackrock.portal.views.admin_cdrs_import'),
-    (r'^admin/portal/readercycle', 'blackrock.portal.views.admin_readercycle'),
-    (r'^admin/', include(admin.site.urls)),
-    (r'^site_media/(?P<path>.*)$', 'django.views.static.serve',
-     {'document_root': site_media_root}),
-    (r'^uploads/(?P<path>.*)$', 'django.views.static.serve',
-     {'document_root': settings.MEDIA_ROOT}),
-    (r'^sampler/', include('blackrock.sampler.urls')),
-    (r'^respiration/', include('blackrock.respiration.urls')),
-    (r'^optimization/', include('blackrock.optimization.urls')),
-    (r'^paleoecology/', include('blackrock.paleoecology.urls')),
-    (r'^waterchemistry/', include('blackrock.waterquality.urls')),
-    (r'^waterquality/', include('blackrock.waterquality.urls')),
-    (r'^treegrowth/', include('blackrock.treegrowth.urls')),
-    (r'^blackrock_main/', include('blackrock.blackrock_main.urls')),
+urlpatterns = [
+    url('^accounts/', include('djangowind.urls')),
+    url(r'^smoketest/', include('smoketest.urls')),
+    url(r'^pagetree/', include('pagetree.urls')),
+    url(r'^admin/portal/rebuild_index',
+        'blackrock.portal.views.admin_rebuild_index'),
+    url(r'^admin/portal/import_cdrs',
+        'blackrock.portal.views.admin_cdrs_import'),
+    url(r'^admin/portal/readercycle',
+        'blackrock.portal.views.admin_readercycle'),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^site_media/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': site_media_root}),
+    url(r'^uploads/(?P<path>.*)$', 'django.views.static.serve',
+        {'document_root': settings.MEDIA_ROOT}),
+    url(r'^sampler/', include('blackrock.sampler.urls')),
+    url(r'^respiration/', include('blackrock.respiration.urls')),
+    url(r'^optimization/', include('blackrock.optimization.urls')),
+    url(r'^paleoecology/', include('blackrock.paleoecology.urls')),
+    url(r'^waterchemistry/', include('blackrock.waterquality.urls')),
+    url(r'^waterquality/', include('blackrock.waterquality.urls')),
+    url(r'^treegrowth/', include('blackrock.treegrowth.urls')),
+    url(r'^blackrock_main/', include('blackrock.blackrock_main.urls')),
 
     # portal pagetree content
-    (r'^edit/(?P<path>.*)$', login_required(EditView.as_view(
+    url(r'^edit/(?P<path>.*)$', login_required(EditView.as_view(
         hierarchy_name="main", hierarchy_base="/"))),
-    (r'^portal/', include('blackrock.portal.urls')),
-    (r'^mammals/', include('blackrock.mammals.urls')),
-    (r'^$', 'blackrock.views.index'),
-    (r'^uploads/(?P<path>.*)$',
-     'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
-)
+    url(r'^portal/', include('blackrock.portal.urls')),
+    url(r'^mammals/', include('blackrock.mammals.urls')),
+    url(r'^$', 'blackrock.views.index'),
+    url(r'^uploads/(?P<path>.*)$',
+        'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
+]

--- a/blackrock/waterquality/urls.py
+++ b/blackrock/waterquality/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic.base import TemplateView
 
 from .views import (
@@ -7,8 +7,7 @@ from .views import (
 )
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='waterquality/index.html'),
         name='waterchemistry-index'),
     url(r'^graph/$', GraphingToolView.as_view(),
@@ -23,4 +22,4 @@ urlpatterns = patterns(
     url(r'^teaching/$',
         TemplateView.as_view(template_name='waterquality/teaching.html'),
         name='waterchemistry-teaching'),
-)
+]


### PR DESCRIPTION
convert `urls.py` to 1.10 style. Lists of `url`s instead of `patterns` and direct importing of all views instead of strings.