### PR TITLE
Page title fixes

### DIFF
--- a/blackrock/templates/base.html
+++ b/blackrock/templates/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <head>
 
-    <title>The Virtual Forest Initiative: {% block title %}MY PAGE TITLE{% endblock %}</title>
+    <title>The Virtual Forest Initiative: {% block title %}{% endblock %}</title>
     
     <style media="screen" type="text/css">
         @import "{{STATIC_URL}}css/site.css" ;

--- a/blackrock/templates/treegrowth/base_treegrowth.html
+++ b/blackrock/templates/treegrowth/base_treegrowth.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load staticfiles %}
+{% block title %}Tree Growth{% endblock %}
 {% block css %}
     <link href="{% static 'css/waterquality/waterquality.css' %}" media="all" rel="stylesheet" />
 {% endblock %}

--- a/blackrock/templates/waterquality/base_waterquality.html
+++ b/blackrock/templates/waterquality/base_waterquality.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load staticfiles %}
+{% block title %}Water Chemistry{% endblock %}
 {% block css %}
     <link rel="stylesheet" href="{% static 'js/libraries/jquery-ui-themes-1.8.12/themes/base/jquery-ui.css' %}" type="text/css" media="all" />
 	<link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">


### PR DESCRIPTION
* Add title to tree growth / water chemistry modules
* Remove default "MY PAGE TITLE" sub-title. When no sub title
  is provided, it should just be empty.