### PR TITLE
Use independent y-axis for each column - PMT #107611

### DIFF
--- a/media/js/src/treegrowth/graph.js
+++ b/media/js/src/treegrowth/graph.js
@@ -76,6 +76,7 @@
 
     var initGraph = function(data) {
         var seriesOptions = [];
+        var yAxes = [];
         var headers = [
             'Red_Oak_1_AVG', 'Red_Oak_2_AVG',
             'Red_Oak_3_AVG', 'Red_Oak_4_AVG',
@@ -91,7 +92,14 @@
             }
             seriesOptions.push({
                 name: name,
-                data: data[i]
+                data: data[i],
+                yAxis: i
+            });
+            yAxes.push({
+                title: {
+                    text: name
+                },
+                visible: false
             });
         }
         $('#plot-container').highcharts('StockChart', {
@@ -110,6 +118,7 @@
                 verticalAlign: 'middle',
                 borderWidth: 0
             },
+            yAxis: yAxes,
             series: seriesOptions
         });
     };


### PR DESCRIPTION
This makes it much easier to compare the environmental data to the dendrometer data.

![2016-09-07-100901_1045x273_scrot](https://cloud.githubusercontent.com/assets/59292/18314921/1f7f19d0-74e3-11e6-8df5-6f441dbfd4a0.png)
