### PR TITLE
Fix graph dates in Safari - PMT #107626

### DIFF
--- a/media/js/src/treegrowth/graph.js
+++ b/media/js/src/treegrowth/graph.js
@@ -56,7 +56,9 @@
 
     var parseDate = function(s) {
         var b = s.split(/\D+/);
-        return new Date(b[0], parseInt(b[1]) - 1, b[2], b[3], b[4], b[5]);
+        var date = Date.parse(
+            new Date(b[0], parseInt(b[1]) - 1, b[2], b[3], b[4], b[5]));
+        return date;
     };
 
     /**


### PR DESCRIPTION
I had fixed the error, but hadn't actually made the graph functional on
Safari. The date was being parsed correctly in Safari, I just needed to
convert it to a unix-style timestamp, which I've done with Date.parse().