### PR TITLE
Fix timestamp bug

### DIFF
--- a/media/js/src/treegrowth/graph-utils.js
+++ b/media/js/src/treegrowth/graph-utils.js
@@ -55,21 +55,16 @@ if (typeof Treegrowth === 'undefined') {
 
     var parseDate = function(s) {
         var b = s.split(/\D+/);
-        var date = Date.parse(
-            new Date(b[0], parseInt(b[1]) - 1, b[2], b[3], b[4], b[5]));
+        var date = Date.UTC(b[0], parseInt(b[1]) - 1, b[2], b[3], b[4], b[5]);
         return date;
     };
 
     /**
-     * Convert the first column of each row to its unix timestamp.
+     * Convert the first column of each row to an integer timestamp.
      */
-    var convertToUnixTimestamps = function(data) {
+    var convertToMilliseconds = function(data) {
         for (var i = 0; i < data.length; i++) {
-            var date = Date.parse(data[i][0]);
-            if (isNaN(date)) {
-                // Safari has trouble parsing the date!
-                date = parseDate(data[i][0]);
-            }
+            var date = parseDate(data[i][0]);
             data[i][0] = date;
         }
         return data;
@@ -77,7 +72,7 @@ if (typeof Treegrowth === 'undefined') {
 
     Treegrowth.splitData = splitData;
     Treegrowth.parseDate = parseDate;
-    Treegrowth.convertToUnixTimestamps = convertToUnixTimestamps;
+    Treegrowth.convertToMilliseconds = convertToMilliseconds;
 })();
 
 if (typeof exports !== 'undefined') {

--- a/media/js/src/treegrowth/graph.js
+++ b/media/js/src/treegrowth/graph.js
@@ -158,7 +158,7 @@
                 // Remove header row
                 data.shift();
 
-                data = Treegrowth.convertToUnixTimestamps(data);
+                data = Treegrowth.convertToMilliseconds(data);
 
                 $promise.resolve(Treegrowth.splitData(data));
             },

--- a/media/js/tests/test-graph-utils.js
+++ b/media/js/tests/test-graph-utils.js
@@ -10,11 +10,10 @@ describe('parseDate', function() {
             '2017-03-07 08:20:00'
         ];
 
-        for (var i = 0; i < dates.length; i++) {
-            assert.strictEqual(
-                Date.parse(dates[i]),
-                Treegrowth.parseDate(dates[i]));
-        }
+        assert.strictEqual(Treegrowth.parseDate(dates[0]), 815101200000);
+        assert.strictEqual(Treegrowth.parseDate(dates[1]), 1472691600000);
+        assert.strictEqual(Treegrowth.parseDate(dates[2]), 1475113713000);
+        assert.strictEqual(Treegrowth.parseDate(dates[3]), 1488874800000);
     });
 });
 


### PR DESCRIPTION
Timestamps were getting a timezone offset applied to them in the graph,
which makes the timestamps display as 4 hours ahead of what they should
be.

I've fixed this bug, and changed the code to never rely on
`Date.parse()` because Mozilla advises that this is strongly discouraged:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date