### PR TITLE
:arrow_up: django-databrowse 2016.2.26-ccnmtl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ django-bootstrap3==7.1.0
 django-markwhat==1.5
 django-pagetree==1.2.4
 django-pageblocks==1.0.4
-django-databrowse==2014.9.26
+django-databrowse==2016.2.26-ccnmtl
 factory_boy==2.7.0
 django-debug-toolbar==1.6
 gunicorn==19.6.0


### PR DESCRIPTION
django-databrowse 2016.2.16 has the fix for #108255, but the maintainer
still has not released it to pypi, so I built a release of our own.