### PR TITLE
Add django-debug-toolbar routes

### DIFF
--- a/blackrock/urls.py
+++ b/blackrock/urls.py
@@ -41,3 +41,9 @@ urlpatterns = [
     url(r'^uploads/(?P<path>.*)$', serve,
         {'document_root': settings.MEDIA_ROOT}),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]


### PR DESCRIPTION
Fixes error:

  u'djdt' is not a registered namespace