### PR TITLE
Fix broken urls on tree webcam page - PMT #108063

### DIFF
--- a/blackrock/templates/portal/webcam.html
+++ b/blackrock/templates/portal/webcam.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <link rel="stylesheet" type="text/css" href="{% static 'js/portal/imageflow/imageflow.css' %}" />
 
@@ -73,17 +73,17 @@
       
         <!-- Sunrise -->
         <div id="sunrise" style="display: none;" class="video">
-          <iframe width="480" height="384" src="https://surelink.ccnmtl.columbia.edu/video/?player=download_mp4_v3&file=projects/mp4/virtualforest_time_lapse01_glare.mp4&width=480&height=360&poster=https://blackrock.ccnmtl.columbia.edu{% static 'images/portal/webcam/virtualforest_time_lapse01_glare.jpg' %}&protection=5b9e4fe881b47f0a4ffcaa630dc4f0ca4d36d1e1"></iframe>
+          <iframe width="480" height="384" src="https://surelink.ccnmtl.columbia.edu/video/?player=download_mp4_v3&file=projects/mp4/virtualforest_time_lapse01_glare.mp4&width=480&height=360&poster={% static 'images/portal/webcam/virtualforest_time_lapse01_glare.jpg' %}&protection=5b9e4fe881b47f0a4ffcaa630dc4f0ca4d36d1e1"></iframe>
         </div>    
                 
         <!-- Snow Melting -->
         <div id="snow" style="display: none" class="video">
-          <iframe width="480" height="384" src="https://surelink.ccnmtl.columbia.edu/video/?player=download_mp4_v3&file=projects/mp4/virtualforest_time_lapse03_snow_long.mp4&width=480&height=360&poster=https://blackrock.ccnmtl.columbia.edu{% static 'images/portal/webcam/virtualforest_time_lapse03_snow_long.jpg' %}&protection=c0a8e54641fecf4f2d2daf1ffe96fc5b83c28dca"></iframe>
+          <iframe width="480" height="384" src="https://surelink.ccnmtl.columbia.edu/video/?player=download_mp4_v3&file=projects/mp4/virtualforest_time_lapse03_snow_long.mp4&width=480&height=360&poster={% static 'images/portal/webcam/virtualforest_time_lapse03_snow_long.jpg' %}&protection=c0a8e54641fecf4f2d2daf1ffe96fc5b83c28dca"></iframe>
         </div>
         
         <!-- April Showers -->
         <div id="showers" style="display: none" class="video">
-          <iframe width="480" height="384" src="https://surelink.ccnmtl.columbia.edu/video/?player=download_mp4_v3&file=projects/mp4/virtualforest_time_lapse02_april_showers.mp4&width=480&height=360&poster=https://blackrock.ccnmtl.columbia.edu{% static 'images/portal/webcam/virtualforest_time_lapse02_april_showers.jpg' %}&protection=3bf74c25d2c49a56a6d6c9612134a2d25fb3e1c1"></iframe>
+          <iframe width="480" height="384" src="https://surelink.ccnmtl.columbia.edu/video/?player=download_mp4_v3&file=projects/mp4/virtualforest_time_lapse02_april_showers.mp4&width=480&height=360&poster={% static 'images/portal/webcam/virtualforest_time_lapse02_april_showers.jpg' %}&protection=3bf74c25d2c49a56a6d6c9612134a2d25fb3e1c1"></iframe>
           
         </div>
       </center>


### PR DESCRIPTION
These images were broken, using URLs like:
https://blackrock.ccnmtl.columbia.eduhttps//ccnmtl-blackrock-static-prod.s3.amazonaws.com/media/images/portal/webcam/virtualforest_time_lapse03_snow_long.jpg

I removed the prefix to these URLs to fix the problem - we only need the
S3 url.