### PR TITLE
Fix images in mammal activity

### DIFF
--- a/media/js/mammals/habitat_map_code.js
+++ b/media/js/mammals/habitat_map_code.js
@@ -342,7 +342,11 @@ function add_show_square_mouseout (rect, thing) {
 
 
 function draw_disk_html (disk_path) {
-    return "<img class='habitat_legend_disk' src='" + STATIC_URL + disk_path + "'/>" ;
+    var withoutLeadingSlash = disk_path[0] === '/' ?
+        disk_path.substring(1) :
+        disk_path;
+    return "<img class='habitat_legend_disk' src='" +
+        STATIC_URL + withoutLeadingSlash + "'/>" ;
 }
 
 function show_little_habitat_disks() {


### PR DESCRIPTION
S3 doesn't allow duplicate slashes in the paths.