### PR TITLE
Use render() instead of render_to_response()

### DIFF
--- a/blackrock/mammals/views.py
+++ b/blackrock/mammals/views.py
@@ -14,7 +14,7 @@ from django.contrib.auth.decorators import user_passes_test
 from django.core.paginator import Paginator, InvalidPage, EmptyPage, \
     PageNotAnInteger
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.views.decorators.csrf import csrf_protect
 from re import match
@@ -49,7 +49,8 @@ class rendered_with(object):
         def rendered_func(request, *args, **kwargs):
             items = func(request, *args, **kwargs)
             if isinstance(items, dict):
-                return render_to_response(
+                return render(
+                    request,
                     self.template_name, items,
                     context_instance=RequestContext(request))
             else:

--- a/blackrock/optimization/views.py
+++ b/blackrock/optimization/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse, HttpResponseRedirect
 from django.http import HttpResponseBadRequest
 from django.template import RequestContext
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from blackrock.optimization.models import Tree, Plot
 import csv
 import math
@@ -56,12 +56,12 @@ class Species:
 
 
 def index(request, admin_msg=""):
-    return render_to_response('optimization/index.html',
-                              context_instance=RequestContext(request))
+    return render(request, 'optimization/index.html',
+                  context_instance=RequestContext(request))
 
 
 def run(request):
-    return render_to_response('optimization/run.html')
+    return render(request, 'optimization/run.html')
 
 
 def calculate(request):
@@ -728,4 +728,4 @@ def tree_png(request):
 def test(request):
     trees = Tree.objects.all()
     Plot.objects.get(name="Mount Misery Plot")
-    return render_to_response("optimization/test.html", {'trees': trees})
+    return render(request, "optimization/test.html", {'trees': trees})

--- a/blackrock/paleoecology/views.py
+++ b/blackrock/paleoecology/views.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from pysolr import Solr
 import csv
@@ -14,7 +14,7 @@ import json
 
 def index(request, admin_msg=""):
     ctx = RequestContext(request, {'admin_messages': admin_msg})
-    return render_to_response('paleoecology/index.html', context_instance=ctx)
+    return render(request, 'paleoecology/index.html', context_instance=ctx)
 
 
 def explore(request):
@@ -30,10 +30,10 @@ def explore(request):
 
     samples = [float(sample.depth) for sample in samples]
 
-    return render_to_response('paleoecology/core-explore.html',
-                              {'samples': samples,
-                               'cores': cores,
-                               'intervals': intervals})
+    return render(request, 'paleoecology/core-explore.html',
+                  {'samples': samples,
+                   'cores': cores,
+                   'intervals': intervals})
 
 
 def getpercents(request):

--- a/blackrock/portal/views.py
+++ b/blackrock/portal/views.py
@@ -14,7 +14,7 @@ from django.core import management
 from django.core.cache import cache
 from django.db.models import get_model, DateField
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext, Context
 from django.utils.tzinfo import FixedOffset
 from django.contrib.gis.geos import fromstr
@@ -33,9 +33,9 @@ class rendered_with(object):
             items = func(request, *args, **kwargs)
             if isinstance(items, type({})):
                 ctx = RequestContext(request)
-                return render_to_response(self.template_name,
-                                          items,
-                                          context_instance=ctx)
+                return render(request, self.template_name,
+                              items,
+                              context_instance=ctx)
             else:
                 return items
 
@@ -229,7 +229,7 @@ def process_dataset_meta_fields(dataset, values):
 @user_passes_test(lambda u: u.is_staff)
 def admin_cdrs_import(request):
     if (request.method != 'POST'):
-        return render_to_response('portal/admin_cdrs.html', {})
+        return render(request, 'portal/admin_cdrs.html', {})
 
     created = 0
     updated = 0
@@ -314,7 +314,7 @@ def admin_rebuild_index(request):
         sys.stdout = sys.__stdout__
         ctx['results'] = the_buffer.getvalue().split('\n')[1:-2]
 
-    return render_to_response('portal/admin_solr.html', context_instance=ctx)
+    return render(request, 'portal/admin_solr.html', context_instance=ctx)
 
 
 def admin_readercycle(request):

--- a/blackrock/respiration/views.py
+++ b/blackrock/respiration/views.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.db import connection
 from django.http import HttpResponse, HttpResponseRedirect, \
     HttpResponseForbidden
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from json import dumps
 from django.utils.tzinfo import FixedOffset
@@ -21,8 +21,8 @@ import urllib
 
 def index(request, admin_msg=""):
     ctx = RequestContext(request, {'admin_messages': admin_msg})
-    return render_to_response('respiration/index.html',
-                              context_instance=ctx)
+    return render(request, 'respiration/index.html',
+                  context_instance=ctx)
 
 
 def leaf(request):
@@ -63,10 +63,10 @@ def leaf(request):
             species['percent'] = request.POST[s + '-percent']
             myspecies.append(species)
 
-    return render_to_response(
-        'respiration/leaf.html', {'numspecies': len(myspecies),
-                                  'specieslist': myspecies,
-                                  'scenario_options': scenario_options})
+    return render(request, 'respiration/leaf.html', {
+        'numspecies': len(myspecies),
+        'specieslist': myspecies,
+        'scenario_options': scenario_options})
 
 
 def forest(request):
@@ -107,7 +107,7 @@ def forest(request):
 
     myspecies = get_myspecies(specieslist, request)
 
-    return render_to_response('respiration/forest.html', {
+    return render(request, 'respiration/forest.html', {
         'stations': station_names,
         'years': year_options,
         'numspecies': len(myspecies),

--- a/blackrock/sampler/views.py
+++ b/blackrock/sampler/views.py
@@ -1,6 +1,6 @@
 from blackrock.sampler.models import Tree, Location
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 import csv
 import math
 
@@ -66,7 +66,7 @@ def import_csv_table(table, id_idx, species_idx, x_idx, y_idx, dbh_idx):
 
 
 def index(request):
-    return render_to_response('sampler/index.html')
+    return render(request, 'sampler/index.html')
 
 
 def plot(request):
@@ -93,7 +93,7 @@ def plot(request):
                    'max_y': max_y,
                    })
 
-    return render_to_response('sampler/plot.html', arglist)
+    return render(request, 'sampler/plot.html', arglist)
 
 
 def transect(request):
@@ -145,22 +145,22 @@ def transect(request):
         xlocs[tree.id] = new_x
         ylocs[tree.id] = new_y
 
-    return render_to_response('sampler/transect.html', {
-                              'trees': tree_list,
-                              'scale': scale,
-                              'x_offset': x_offset,
-                              'y_offset': y_offset,
-                              'xlocs': xlocs,
-                              'ylocs': ylocs,
-                              'plot_w': request.POST['plot-w'],
-                              'plot_h': request.POST['plot-h'],
-                              'view_height': view_height,
-                              'view_width': view_width,
-                              'transect_start_x': transect_start_x,
-                              'transect_start_y': transect_start_y,
-                              'transect_end_x': transect_end_x,
-                              'transect_end_y': transect_end_y,
-                              })
+    return render(request, 'sampler/transect.html', {
+        'trees': tree_list,
+        'scale': scale,
+        'x_offset': x_offset,
+        'y_offset': y_offset,
+        'xlocs': xlocs,
+        'ylocs': ylocs,
+        'plot_w': request.POST['plot-w'],
+        'plot_h': request.POST['plot-h'],
+        'view_height': view_height,
+        'view_width': view_width,
+        'transect_start_x': transect_start_x,
+        'transect_start_y': transect_start_y,
+        'transect_end_x': transect_end_x,
+        'transect_end_y': transect_end_y,
+    })
 
 
 def calculate_theta(x1, x2, y1, y2):
@@ -235,23 +235,23 @@ def worksheet(request):
         xlocs[tree.id] = new_x  # + 30
         ylocs[tree.id] = new_y  # + 16
 
-    return render_to_response('sampler/worksheet.html', {
-                              'trees': tree_list,
-                              'xlocs': xlocs,
-                              'ylocs': ylocs,
-                              'range': range(1, 21),
-                              'transect_start_x': x1,
-                              'transect_start_y': y1,
-                              'transect_end_x': x2,
-                              'transect_end_y': y2,
-                              'scale': scale,
-                              'x_offset': x_offset,
-                              'y_offset': y_offset,
-                              'plot_w': request.POST['plot-w'],
-                              'plot_h': request.POST['plot-h'],
-                              'view_height': view_height,
-                              'view_width': view_width,
-                              })
+    return render(request, 'sampler/worksheet.html', {
+        'trees': tree_list,
+        'xlocs': xlocs,
+        'ylocs': ylocs,
+        'range': range(1, 21),
+        'transect_start_x': x1,
+        'transect_start_y': y1,
+        'transect_end_x': x2,
+        'transect_end_y': y2,
+        'scale': scale,
+        'x_offset': x_offset,
+        'y_offset': y_offset,
+        'plot_w': request.POST['plot-w'],
+        'plot_h': request.POST['plot-h'],
+        'view_height': view_height,
+        'view_width': view_width,
+    })
 
 
 def adjust_theta_by_quadrant(theta, x1, x2, y1, y2):
@@ -292,4 +292,4 @@ def export_csv(request):
 
 
 def csv_info(request):
-    return render_to_response('sampler/csvinfo.html')
+    return render(request, 'sampler/csvinfo.html')

--- a/blackrock/templates/paleoecology/core-explore.html
+++ b/blackrock/templates/paleoecology/core-explore.html
@@ -1,5 +1,5 @@
 {% extends "paleoecology/base_paleoecology.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load paleo-extras %}
 
 {% block pagetitle %}Sediment Sampling{% endblock %}

--- a/media/js/paleoecology/explore.js
+++ b/media/js/paleoecology/explore.js
@@ -67,8 +67,8 @@ function showResults(http_request) {
     var countString = '<br />';
     for (var i = 0; i < pollen.length; i++) {
         var imgString = '<div class="pollen-zoo-image core">' +
-            '<div id="pollen-image"><img src="' + STATIC_URL +
-            'images/paleoecology/pollen/' +
+            '<div id="pollen-image-' + i + '">' +
+            '<img src="' + STATIC_URL + 'images/paleoecology/pollen/' +
             getImage(pollen[i]) + '"/></div>';
         countString += imgString + '<div class="imagename"><b>' + pollen[i] +
             ':</b><br /> ' + counts[i] + ' grains <br /></div></div>';


### PR DESCRIPTION
As recommended by the Django docs:
https://docs.djangoproject.com/en/1.10/topics/http/shortcuts/#render-to-response

Now the static context processor is available in a bunch of views that
are relying on the `STATIC_URL` context variable, fixing some more
broken images.