### PR TITLE
set SPATIALITE_LIBRARY_PATH

### DIFF
--- a/blackrock/settings_shared.py
+++ b/blackrock/settings_shared.py
@@ -7,7 +7,7 @@ project = 'blackrock'
 base = os.path.dirname(__file__)
 locals().update(common(project=project, base=base))
 
-if platform.linux_distribution()[1] != '14.04':
+if platform.linux_distribution()[1] == '16.04':
     # 15.04 and later need this set, but it breaks
     # on trusty.
     # yeah, it's not really going to work on non-Ubuntu

--- a/blackrock/settings_shared.py
+++ b/blackrock/settings_shared.py
@@ -1,3 +1,4 @@
+import platform
 import os.path
 import sys
 from ccnmtlsettings.shared import common
@@ -6,7 +7,15 @@ project = 'blackrock'
 base = os.path.dirname(__file__)
 locals().update(common(project=project, base=base))
 
-SPATIALITE_LIBRARY_PATH = 'mod_spatialite'
+if platform.linux_distribution()[1] != '14.04':
+    # 15.04 and later need this set, but it breaks
+    # on trusty.
+    # yeah, it's not really going to work on non-Ubuntu
+    # systems either, but I don't know a good way to
+    # check for the specific issue. Anyone not running
+    # ubuntu will just need to set this to the
+    # appropriate value in their local_settings.py
+    SPATIALITE_LIBRARY_PATH = 'mod_spatialite'
 
 DATABASES = {
     'default': {

--- a/blackrock/settings_shared.py
+++ b/blackrock/settings_shared.py
@@ -6,6 +6,8 @@ project = 'blackrock'
 base = os.path.dirname(__file__)
 locals().update(common(project=project, base=base))
 
+SPATIALITE_LIBRARY_PATH = 'mod_spatialite'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',


### PR DESCRIPTION
fixes a bug on Ubuntu 16.04, explained here: https://code.djangoproject.com/ticket/26137