### PR TITLE
render portal page when there is no content

### DIFF
--- a/blackrock/portal/views.py
+++ b/blackrock/portal/views.py
@@ -56,9 +56,13 @@ def page(request, path):
     asset_type = request.GET.get('type', None)
     asset_id = request.GET.get('id', None)
 
+    root = None
+    if len(ancestors) > 0:
+        root = ancestors[0]
+
     context = dict(section=section,
                    module=module,
-                   root=ancestors[0])
+                   root=root)
 
     if asset_type and asset_id:
         try:


### PR DESCRIPTION
Just addressing a small developer quality of life issue. If you spin up
a new instance without any content in the database, the portal page,
which is currently the default, just gives a 500 error.

With this, the portal page isn't terribly useful since there is no
content there by default, but at least you get a basic page with
navigation on the first load and know that your install is basically
working rather than a 500 error.