### PR TITLE
Disable data grouping - PMT #111565

### DIFF
--- a/media/js/src/treegrowth/graph.js
+++ b/media/js/src/treegrowth/graph.js
@@ -197,6 +197,13 @@
                         }
                     }
                 }
+            },
+            plotOptions: {
+                line: {
+                    dataGrouping: {
+                        enabled: false
+                    }
+                }
             }
         });
     };


### PR DESCRIPTION
This hurts graph performance for wide date ranges but now the display
and exported data is always accurate.