### PR TITLE
Fix invalid characters

### DIFF
--- a/blackrock/settings_production.py
+++ b/blackrock/settings_production.py
@@ -32,7 +32,7 @@ except ImportError:
 
 
 if hasattr(settings, 'SENTRY_DSN'):
-￼   sentry_sdk.init(
-￼       dsn=SENTRY_DSN,
-￼       integrations=[DjangoIntegration()],
-￼   )
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+    )

--- a/blackrock/settings_staging.py
+++ b/blackrock/settings_staging.py
@@ -32,8 +32,8 @@ except ImportError:
 
 
 if hasattr(settings, 'SENTRY_DSN'):
-￼   sentry_sdk.init(
-￼       dsn=SENTRY_DSN,
-￼       integrations=[DjangoIntegration()],
-￼       debug=True,
-￼   )
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        debug=True,
+    )


### PR DESCRIPTION
This was caused by some copy-and-pasting I did from github to this file.
Which is why we need to enable flake8 checks for these settings files.