### PR TITLE
Update security settings

### DIFF
--- a/blackrock/settings_shared.py
+++ b/blackrock/settings_shared.py
@@ -71,6 +71,9 @@ TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
 
 MIDDLEWARE += [  # noqa
     'blackrock.portal.middleware.ValueErrorMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
 ]
 
 INSTALLED_APPS += [  # noqa
@@ -127,6 +130,12 @@ FIVE_HOURS = 60 * 60 * 5
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_SAVE_EVERY_REQUEST = True
 SESSION_COOKIE_AGE = FIVE_HOURS
+
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_HTTPONLY = True
 
 MAX_DATA_COUNT = 12000
 


### PR DESCRIPTION
* Add X-Frame-Option header to all responses
The header value is set to SAMEORIGIN by default. See more (https://docs.djangoproject.com/en/2.2/ref/clickjacking/)

* Set HttpOnly flag for Django cookies
https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-cookie-httponly and https://docs.djangoproject.com/en/2.2/ref/settings/#session-cookie-httponly

* Flag CSRF cooke as secure
https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-cookie-secure

* Add SecurityMiddleware
https://docs.djangoproject.com/en/2.2/ref/middleware/#module-django.middleware.security

* Add CSRF Middleware
https://docs.djangoproject.com/en/2.2/ref/middleware/#csrf-protection-middleware
