### PR TITLE
Short circuit data browse to display objects only

### DIFF
--- a/blackrock/portal/urls.py
+++ b/blackrock/portal/urls.py
@@ -3,11 +3,11 @@ import os.path
 from django.conf.urls import url
 from django.views.generic.base import TemplateView
 import django.views.static
-import django_databrowse
+
 
 from blackrock.portal.search import PortalSearchView, PortalSearchForm
 
-from blackrock.portal.views import PortalPageView, nearby
+from blackrock.portal.views import PortalPageView, nearby, portal_databrowse
 
 
 media_root = os.path.join(os.path.dirname(__file__), "media")
@@ -15,10 +15,10 @@ media_root = os.path.join(os.path.dirname(__file__), "media")
 urlpatterns = [
     url(r'^media/(?P<path>.*)$', django.views.static.serve,
         {'document_root': media_root}),
-    url(r'^browse/(.*)', django_databrowse.site.root),
+    url(r'^browse/(.*)', portal_databrowse),
     url(r'^search/', PortalSearchView(
         template="portal/search.html",
-        form_class=PortalSearchForm), name='search'),
+        form_class=PortalSearchForm), name='portal-search'),
     url(r'^nearby/(?P<latitude>-?\d+\.\d+)/(?P<longitude>-?\d+\.\d+)/$',
         nearby),
     url(r'^weather/$', TemplateView.as_view(

--- a/blackrock/portal/views.py
+++ b/blackrock/portal/views.py
@@ -17,8 +17,11 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import DateField
 from django.http import HttpResponse
+from django.http.response import HttpResponseRedirect
 from django.shortcuts import render
+from django.urls.base import reverse
 from django.views.generic.base import TemplateView
+import django_databrowse
 from pagetree.models import Hierarchy
 from pysolr import Solr, SolrError
 
@@ -86,6 +89,15 @@ class PortalPageView(TemplateView):
                 ctx['error'] = msg % (asset_type)
 
         return ctx
+
+
+def portal_databrowse(request, url):
+    url = url.rstrip('/')  # Trim trailing slash, if it exists.
+
+    if 'objects' in url:
+        return django_databrowse.site.root(request, url)
+    else:
+        return HttpResponseRedirect(reverse('portal-search'))
 
 
 @rendered_with('portal/nearby.html')


### PR DESCRIPTION
django-databrowse is a great library for browsing object models. However, Blackrock doesn't really need all this functionality and there's not an easy way to tell the library exactly what we want. There's also some older code in django-databrowse that is sparking 500 errors. This PR circumvents the issues by doing a little url routing before handing the action back to databrowse.