### PR TITLE
:arrow_up: pyyaml 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ django-extensions==3.2.0
 ctlsettings==0.3.1
 
 pbr==6.0.0
-pyyaml==6.0
+pyyaml==6.0.1
 stevedore>=1.20.0 # Apache-2.0
 bandit==1.7.1
 


### PR DESCRIPTION
This fixes a build error on python 3.12.